### PR TITLE
Small improvements to hierarchicalXC

### DIFF
--- a/extreme_classification/hierarchicalXC/classifier.py
+++ b/extreme_classification/hierarchicalXC/classifier.py
@@ -80,10 +80,10 @@ class HierarchicalXC(object):
         Returns:
             classes : the class predictions for each data point
         """
-        self.X = X.toarray()
+        self.test_X = X.toarray()
         start_id = len(self.merge_iterations) - 1
-        self.classes = ssp.lil_matrix(np.zeros((len(self.X), self.num_classes)))
-        ids = np.arange(len(self.X))
+        self.classes = ssp.lil_matrix(np.zeros((len(self.test_X), self.num_classes)))
+        ids = np.arange(len(self.test_X))
         self.traverse_classifiers(start_id, ids)
         return self.classes
 
@@ -99,9 +99,9 @@ class HierarchicalXC(object):
         """
         classifier, is_true_classifier = self.classifiers[current_id]
         if not is_true_classifier:
-            preds = np.array([[1, 1]] * len(self.X[this_ids]))
+            preds = np.array([[1, 1]] * len(self.test_X[this_ids]))
         else:
-            preds = classifier.predict(self.X[this_ids])
+            preds = classifier.predict(self.test_X[this_ids])
         ids = []
         classifier_ids = []
         for c in range(2):

--- a/extreme_classification/hierarchicalXC/classifier.py
+++ b/extreme_classification/hierarchicalXC/classifier.py
@@ -80,14 +80,14 @@ class HierarchicalXC(object):
         Returns:
             classes : the class predictions for each data point
         """
-        X = X.toarray()
+        self.X = X.toarray()
         start_id = len(self.merge_iterations) - 1
-        classes = ssp.lil_matrix(np.zeros((len(X), self.num_classes)))
-        ids = np.arange(len(X))
-        self.traverse_classifiers(start_id, X, ids, classes)
-        return classes
+        self.classes = ssp.lil_matrix(np.zeros((len(self.X), self.num_classes)))
+        ids = np.arange(len(self.X))
+        self.traverse_classifiers(start_id, ids)
+        return self.classes
 
-    def traverse_classifiers(self, current_id, X, this_ids, classes):
+    def traverse_classifiers(self, current_id, this_ids):
         """
         Traverses a node in the tree of classifers, and recursively calls itself to traverse child
         nodes
@@ -99,9 +99,9 @@ class HierarchicalXC(object):
         """
         classifier, is_true_classifier = self.classifiers[current_id]
         if not is_true_classifier:
-            preds = np.array([[1, 1]] * len(X[this_ids]))
+            preds = np.array([[1, 1]] * len(self.X[this_ids]))
         else:
-            preds = classifier.predict(X[this_ids])
+            preds = classifier.predict(self.X[this_ids])
         ids = []
         classifier_ids = []
         for c in range(2):
@@ -110,6 +110,6 @@ class HierarchicalXC(object):
                 continue
             classifier_ids = self.merge_iterations[current_id][c]
             if classifier_ids < self.num_classes:
-                classes[ids, classifier_ids] = 1
+                self.classes[ids, classifier_ids] = 1
             else:
-                self.traverse_classifiers(classifier_ids - self.num_classes, X, ids, classes)
+                self.traverse_classifiers(classifier_ids - self.num_classes, ids)

--- a/extreme_classification/hierarchicalXC/classifier.py
+++ b/extreme_classification/hierarchicalXC/classifier.py
@@ -89,10 +89,11 @@ class HierarchicalXC(object):
         X = X.toarray()
         start_id = len(self.merge_iterations) - 1
         classes = ssp.lil_matrix(np.zeros((len(X), self.num_classes)))
-        self.traverse_classifiers(start_id, X, classes)
+        ids = np.arange(len(X))
+        self.traverse_classifiers(start_id, X, ids, classes)
         return classes
 
-    def traverse_classifiers(self, current_id, X, classes):
+    def traverse_classifiers(self, current_id, X, this_ids, classes):
         """
         Traverses a node in the tree of classifers, and recursively calls itself to traverse child
         nodes
@@ -103,17 +104,15 @@ class HierarchicalXC(object):
             classes : class predictions for all the test data points
         """
         classifier = self.classifiers[current_id]
-        preds = classifier.predict(X)
+        preds = classifier.predict(X[this_ids])
         ids = []
-        X_sub = []
         classifier_ids = []
         for c in range(2):
-            ids = np.where(preds[:, c] == 1)[0]
+            ids = this_ids[np.where(preds[:, c] == 1)[0]]
             if(len(ids)) == 0:
                 continue
-            X_sub = X[ids]
             classifier_ids = self.merge_iterations[current_id][c]
             if classifier_ids < self.num_classes:
                 classes[ids, classifier_ids] = 1
             else:
-                self.traverse_classifiers(classifier_ids - self.num_classes, X_sub, classes)
+                self.traverse_classifiers(classifier_ids - self.num_classes, X, ids, classes)


### PR DESCRIPTION
* Stop creating dummy classifiers and traversing down the tree when all child classes must anyway be predicted
* Stop creating fresh copies of data to pass in each recursive call. Fix a bug in indexing.